### PR TITLE
Replace failing tests

### DIFF
--- a/tests/testthat/test_subsidiaryFunctions.R
+++ b/tests/testthat/test_subsidiaryFunctions.R
@@ -102,11 +102,11 @@ test_that("Testing the built-in plotting function", {
     p5 <- superbPlot.pointjitterviolin(dta, "dose", 
          "supp", ".~dose", tg, list(color="black"), list(color="purple") ) +
         scale_x_continuous("mean ratings")
-    expect_output( str(p1), "List of 9")
-    expect_output( str(p2), "List of 9")
-    expect_output( str(p3), "List of 9")
-    expect_output( str(p4), "List of 9")
-    expect_output( str(p5), "List of 9")
+    expect_s3_class(p1, "ggplot")
+    expect_s3_class(p2, "ggplot")
+    expect_s3_class(p3, "ggplot")
+    expect_s3_class(p4, "ggplot")
+    expect_s3_class(p5, "ggplot")
 })
 
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break superb.

This PR replaces tests that caused the breakage. In short, testing for the `str()` output of a ggplot is brittle and may differ upon internal changes of ggplot2.  The tests are replaced with a test that the code has in fact returned a ggplot object.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help superb get out a fix if necessary.